### PR TITLE
Fix #6 Handle 'eval/compile' by accessing the outer frame

### DIFF
--- a/scalene/scalene.py
+++ b/scalene/scalene.py
@@ -61,6 +61,7 @@ class scalene(object):
     total_cpu_samples      = 0           # how many CPU    samples have been collected.
     total_malloc_samples   = 0           # "   "    malloc "       "    "    "
     total_free_samples     = 0           # "   "    free   "       "    "    "
+    current_footprint = 0
     signal_interval        = 0.01        # seconds between interrupts for CPU sampling.
     elapsed_time           = 0           # total time spent in program being profiled.
     memory_sampling_rate   = 64 * 1024   # we get signals after this many bytes are allocated/freed. 

--- a/scalene/scalene.py
+++ b/scalene/scalene.py
@@ -106,6 +106,8 @@ class scalene(object):
         elapsed_since_last_signal = now - scalene.last_signal_time
         fname = frame.f_code.co_filename
         # Record samples only for files we care about.
+        if (len(fname)) == 0:
+            fname = frame.f_back.f_code.co_filename
         if not scalene.should_trace(fname):
             return
         # Here we take advantage of an apparent limitation of Python:


### PR DESCRIPTION
'eval/compile' gives no `f_code.co_filename`. We have to look back into the outer frame in order to check the `co_filename`. Hence a line is added to look back by one frame if the `co_filename` is empty. This fixes #6 .