### PR TITLE
Output handling improvements

### DIFF
--- a/scalene/scalene.py
+++ b/scalene/scalene.py
@@ -236,7 +236,7 @@ class Scalene():
                     print("-" * 80, file=out)
                     contents = source_file.readlines()
                     for line_no, line in enumerate(contents, 1):
-                        line = line[:-1] # Strip newline
+                        line = line.rstrip() # Strip newline
                         # Prepare output values.
                         n_cpu_samples_c = Scalene.cpu_samples_c[fname][line_no]
                         # Correct for negative CPU sample counts.

--- a/scalene/scalene.py
+++ b/scalene/scalene.py
@@ -225,10 +225,12 @@ class Scalene():
             for fname in sorted(all_instrumented_files):
 
                 this_cpu_samples = sum(Scalene.cpu_samples_c[fname].values()) + sum(Scalene.cpu_samples_python[fname].values())
-                if this_cpu_samples == 0:
-                    percent_cpu_time = 0
-                else:
+
+                try:
                     percent_cpu_time = 100 * this_cpu_samples / Scalene.total_cpu_samples
+                except ZeroDivisionError:
+                    percent_cpu_time = 0
+
                 # percent_cpu_time = 100 * this_cpu_samples * Scalene.mean_signal_interval / Scalene.elapsed_time
                 print(f"{fname}: % of CPU time = {percent_cpu_time:6.2f}% out of {Scalene.elapsed_time:6.2f}s.", file=out)
                 print(f"  \t | {'CPU %':9}| {'CPU %':9}| {'Memory (MB) |' if did_sample_memory else ''}", file=out)

--- a/scalene/scalene.py
+++ b/scalene/scalene.py
@@ -235,8 +235,7 @@ class Scalene():
                     print(f"  Line\t | {'(Python)':9}| {'(C)':9}|{'             |' if did_sample_memory else ''} [{fname}]", file=out)
                     print("-" * 80, file=out)
                     contents = source_file.readlines()
-                    line_no = 1
-                    for line in contents:
+                    for line_no, line in enumerate(contents, 1):
                         line = line[:-1] # Strip newline
                         # Prepare output values.
                         n_cpu_samples_c = Scalene.cpu_samples_c[fname][line_no]
@@ -266,7 +265,6 @@ class Scalene():
                             # print(f"{line_no:6d}\t | {n_cpu_percent_python_str:9s}| {n_cpu_percent_c_str:9s}| {n_mem_mb_str:11s} | {line}", file=out)
                         else:
                             print(f"{line_no:6d}\t | {n_cpu_percent_python_str:9s}| {n_cpu_percent_c_str:9s}| {line}", file=out)
-                        line_no += 1
                     print("", file=out)
 
 


### PR DESCRIPTION
Slightly modifies the output handling of scalene to:
1. Avoid reading the entire source file into memory, instead processing it line by line.
2. Use enumerate to track the line number.
3. Use str.rstrip to more reliably remove all trailing whitespace.
4. Fixes a possible divide by zero.  If `this_cpu_samples` is zero then the expression for `percent_cpu_time` will evaluate to zero anyway. Further down, there is a check for `Scalene.total_cpu_samples` being zero.  I'm guessing what was meant to be checked here was `Scalene.total_cpu_samples`.