### PR TITLE
Add pytest.ini to run tests successfuly

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = *.py


### PR DESCRIPTION
The files into test folder not follow the naming convetion for pytest
module. So, when we run directly `python3 -m pytest test` or
`python3 setup.py test` 0 test run. This can be complicated when we try
to packaging, i.e. Debian.

In this PR propose the creation of a python.ini file to find the files
inside the test folder with the *.py naming.