### PR TITLE
Add install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,9 @@ setup(
         "Operating System :: MacOS :: MacOS X"
     ],
     packages=find_packages(),
+    install_requires=[
+        "rich>=2.0.0"
+    ],
     include_package_data=True,
     entry_points={"console_scripts": ["scalene = scalene.__main__:main"]},
     python_requires=">=3.5",


### PR DESCRIPTION
`setup.py` file misses the `install_requires` which will cause a `ModuleNotFoundError` when the `rich` package not in the user environment.


--------------------------------------------------
```
    from rich.console import Console
ModuleNotFoundError: No module named 'rich'
```