### PR TITLE
expose errors when calling main

### DIFF
--- a/scalene/__main__.py
+++ b/scalene/__main__.py
@@ -1,9 +1,12 @@
+import sys
+
 def main():
     try:
         from scalene import scalene
         scalene.Scalene.main()
-    except:
-        pass
+    except Exception as exc:
+        sys.stderr.write("ERROR: Calling scalene main function failed: %s\n" % exc)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Problems that occur when calling `scalene.Scalene.main` should not be swept under the rug, but should be exposed as an error and trigger a non-zero exit code.

I'm not 100% sure the proposed change is OK, but the current code was very effective at hiding a problem with my installation of `scalene` 1.1.1 (see #76).