### PR TITLE
Fix naming conflicts and add in poll shim

### DIFF
--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -6,7 +6,7 @@ import traceback
 import statistics
 
 python = "python3"
-progname = "/Users/emery/git/scalene/benchmarks/julia1_nopil.py"
+progname = os.path.join(os.path.dirname(__file__), "julia1_nopil.py")
 number_of_runs = 1 # We take the average of this many runs.
 
 # Output timing string from the benchmark.
@@ -133,7 +133,7 @@ benchmarks = [(baseline, "baseline", "_original program_"), (cprofile, "cProfile
 
 # benchmarks = [(baseline, "baseline", "_original program_"), (pprofile_deterministic, "`pprofile` _(deterministic)_")]
 # benchmarks = [(baseline, "baseline", "_original program_"), (pprofile_statistical, "pprofile_statistical", "`pprofile` _(statistical)_")]
-benchmarks = [(baseline, "baseline", "_original program_"), (py_spy, "py_spy", "`py-spy`")]
+benchmarks = [(baseline, "baseline", "_original program_"), (py_spy, "py_spy", "`py-spy`"), (scalene_cpu, "scalene_cpu", "`scalene` _(CPU only)_"), (scalene_cpu_memory, "scalene_cpu_memory", "`scalene` _(CPU + memory)_")]
 
 average_time = {}
 check = ":heavy_check_mark:"

--- a/scalene/__main__.py
+++ b/scalene/__main__.py
@@ -1,12 +1,14 @@
 import sys
 
+
 def main():
     try:
-        from scalene import scalene
-        scalene.Scalene.main()
+        from scalene import entrypoint
+        entrypoint.Scalene.main()
     except Exception as exc:
         sys.stderr.write("ERROR: Calling scalene main function failed: %s\n" % exc)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scalene/__main__.py
+++ b/scalene/__main__.py
@@ -3,8 +3,8 @@ import sys
 
 def main():
     try:
-        from scalene import entrypoint
-        entrypoint.Scalene.main()
+        from scalene import scalene_profiler
+        scalene_profiler.Scalene.main()
     except Exception as exc:
         sys.stderr.write("ERROR: Calling scalene main function failed: %s\n" % exc)
         sys.exit(1)

--- a/scalene/entrypoint.py
+++ b/scalene/entrypoint.py
@@ -1078,7 +1078,7 @@ start the timer interrupts."""
         if filename[0] == "<":
             # Not a real file.
             return False
-        if "scalene.py" in filename or "scalene/__main__.py" in filename:
+        if "entrypoint.py" in filename or "scalene/__main__.py" in filename:
             # Don't profile the profiler.
             return False
         if Scalene.__profile_all:

--- a/scalene/scalene_profiler.py
+++ b/scalene/scalene_profiler.py
@@ -1089,7 +1089,7 @@ start the timer interrupts."""
         if filename[0] == "<":
             # Not a real file.
             return False
-        if "entrypoint.py" in filename or "scalene/__main__.py" in filename:
+        if "scalene_profiler.py" in filename or "scalene/__main__.py" in filename:
             # Don't profile the profiler.
             return False
         if Scalene.__profile_all:


### PR DESCRIPTION
Renamed `scalene.py` to `entrypoint.py` to prevent some conflicts observed in importing with benchmarks. Made benchmark import relative. Added in `ReplacementPollSelector` to avoid dropped signals in long-running `poll`s. 